### PR TITLE
Fixing the specific type check against a global one

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -40,7 +40,16 @@ trait HasPermissions {
     public function can($permission, $target_type = null, $target_id = null)
     {
         if(!$this->hasPermission($permission, $target_type, $target_id))
+        {
+            if($this->hasPermission($permission, $target_type))
+            {
+                $permission = $this->getPermission($permission, $target_type);
+
+                return (bool) !$this->is_prohibited;
+            }
+
             return false;
+        }
 
         $permission = $this->getPermission($permission, $target_type, $target_id);
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -53,10 +53,7 @@ trait HasPermissions {
 
         $permission = $this->getPermission($permission, $target_type, $target_id);
 
-        if($permission->is_prohibited)
-            return false;
-
-        return true;
+        return !$permission->is_prohibited;
     }
 
     public function cannot($permission, $target_type = null, $target_id = null)

--- a/tests/ModelSpecificTest.php
+++ b/tests/ModelSpecificTest.php
@@ -101,4 +101,19 @@ class ModelSpecificTest extends TestCase {
         $this->assertTrue($this->user->cannot('edit', $this->targetInstance, 0));
     }
 
+    public function testGlobalToSpecific()
+    {
+        $this->user->allow('edit', $this->targetInstance);
+
+        $this->assertEquals($this->user->permissions()->count(), 1);
+        $this->assertfalse($this->user->hasPermission('edit', $this->targetInstance, $this->targetInstanceId));
+        $this->assertTrue($this->user->hasPermission('edit', $this->targetInstance));
+        $this->assertEquals($this->user->allowedPermissions()->count(), 1);
+        $this->assertEquals($this->user->prohibitedPermissions()->count(), 0);
+        $this->assertTrue($this->user->can('edit', $this->targetInstance, $this->targetInstanceId));
+        $this->assertTrue($this->user->can('edit', $this->targetInstance));
+        $this->assertFalse($this->user->cannot('edit', $this->targetInstance, $this->targetInstanceId));
+        $this->assertFalse($this->user->cannot('edit', $this->targetInstance));
+    }
+
 }


### PR DESCRIPTION
If a model has a global type (ex: can edit any `App\Post`), then when calling 
```php
$user->can('edit', App\Post::class, 'specific_id');
```
should get true. If the user can edit any post, it can edit even a specific one.